### PR TITLE
swiftmailer v6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "silverstripe/framework" : ">=4.6 <4.9",
+        "silverstripe/framework" : "^4.9",
         "silverstripe/tagfield" : "^2",
         "silverstripe/taxonomy" : "^2"
     },

--- a/src/Email/TaggableEmail.php
+++ b/src/Email/TaggableEmail.php
@@ -2,6 +2,7 @@
 
 namespace NSWDPC\Messaging\Taggable;
 
+use Egulias\EmailValidator\EmailValidator;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Control\Email\Email;
 
@@ -54,7 +55,7 @@ class TaggableEmail extends Email {
                 $factory = new \Swift_Mime_SimpleHeaderFactory(
                     new \Swift_Mime_HeaderEncoder_Base64HeaderEncoder(),
                     new \Swift_Encoder_Base64Encoder(),
-                    new \Swift_Mime_Grammar()
+                    new EmailValidator()
                 );
                 // each tag
                 foreach($tags as $index => $tag) {


### PR DESCRIPTION
## Changes

+ Restrict to `silverstripe/framework:^4.9`
+ `Swift_Mime_Grammar` -> `EmailValidator`