### PR TITLE
Fix: email instance may not support tagging

### DIFF
--- a/src/Extensions/UserDefinedFormControllerExtension.php
+++ b/src/Extensions/UserDefinedFormControllerExtension.php
@@ -21,6 +21,12 @@ class UserDefinedFormControllerExtension extends Extension
      */
     public function updateEmail(Email $email, EmailRecipient $recipient, array $emailData)
     {
+
+        // Bail if the $email instance doesn't support tagging
+        if(!($email instanceof TaggableEmail)) {
+            return;
+        }
+
         // @phpstan-ignore class.notFound
         $tags = $recipient->EmailTags()->sort('Name');
         $availableTags = NotificationTags::filterTermsByAvailable($tags);

--- a/src/Extensions/UserDefinedFormControllerExtension.php
+++ b/src/Extensions/UserDefinedFormControllerExtension.php
@@ -23,7 +23,7 @@ class UserDefinedFormControllerExtension extends Extension
     {
 
         // Bail if the $email instance doesn't support tagging
-        if(!($email instanceof TaggableEmail)) {
+        if (!($email instanceof TaggableEmail)) {
             return;
         }
 


### PR DESCRIPTION
## Changes

+ An email instance is passed to `updateEmail` but it may not support notification tags